### PR TITLE
Fix firmware upload feature in mks_robin_nano35.py

### DIFF
--- a/buildroot/share/PlatformIO/scripts/mks_robin_nano35.py
+++ b/buildroot/share/PlatformIO/scripts/mks_robin_nano35.py
@@ -38,3 +38,8 @@ def encrypt(source, target, env):
         firmware.close()
         robin.close()
 env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", encrypt);
+
+env.Replace(
+    UPLOADER="curl",
+    UPLOADCMD="$UPLOADER -v -H 'Content-Type:application/octet-stream' http://$UPLOADERFLAGS/upload?X-Filename=Robin_Nano35.bin --data-binary @$BUILD_DIR/Robin_nano35.bin"
+)


### PR DESCRIPTION
Для загрузки прошивки по WiFi (как описано в README) используется скрипт `mks_robin_nano35.py`, но в нем в отличии от `mks_robin_nano.py` нет секции которая настраивает curl. Из-за этого загрузка прошивок по WiFi не работает.

Поэтому чтобы починить эту фичу просто скопировал настройки для загрузки прошивки по WiFi из mks_robin_nano.py.